### PR TITLE
Treat non-zero exit code as error (fix exception)

### DIFF
--- a/src/leiningen/sassc.clj
+++ b/src/leiningen/sassc.clj
@@ -49,7 +49,7 @@
     (as-> (compile-node node) %
           (case (:exit %)
             0 (println (:out %))
-            1 (println (:err %))))))
+            (println (:err %))))))
 
 
 (defn- clean


### PR DESCRIPTION
Fix exception caused by latest version of sassc (3.4.8), which returns several different non-zero exit codes in case of error.